### PR TITLE
Fix fhir server url in node adapter

### DIFF
--- a/src/adapters/node.js
+++ b/src/adapters/node.js
@@ -18,6 +18,9 @@
             if(args.url) {
                 args.url = args.url.replace(args.baseUrl, '');
             }
+            if(args.url === '') {
+              args.url = '/';
+            }
             args.json = true;
             if(args.debug){
                 console.log('DEBUG[node]: (requrest)', args); 


### PR DESCRIPTION
Fix fhir server url in node adapter when base url is root